### PR TITLE
add support for command line arguments to be passed on to python script (-py option)

### DIFF
--- a/scribus/plugins/scriptplugin/scriptercore.cpp
+++ b/scribus/plugins/scriptplugin/scriptercore.cpp
@@ -230,10 +230,10 @@ void ScripterCore::RecentScript(QString fn)
 void ScripterCore::slotRunScriptFile(QString fileName, bool inMainInterpreter)
 {
 	QStringList arguments = QStringList();
-	slotRunScriptFileArgs(fileName, arguments, inMainInterpreter);
+	slotRunScriptFile(fileName, arguments, inMainInterpreter);
 }
 
-void ScripterCore::slotRunScriptFileArgs(QString fileName, QStringList arguments, bool inMainInterpreter)
+void ScripterCore::slotRunScriptFile(QString fileName, QStringList arguments, bool inMainInterpreter)
 /** run "filename" python script with the additional arguments provided in "arguments" */
 {
 	// Prevent two scripts to be run concurrently or face crash!
@@ -376,7 +376,7 @@ void ScripterCore::slotRunPythonScript()
 {
 	if (!ScQApp->pythonScript.isNull())
 	{
-		slotRunScriptFileArgs(ScQApp->pythonScript, ScQApp->pythonScriptArgs, true);
+		slotRunScriptFile(ScQApp->pythonScript, ScQApp->pythonScriptArgs, true);
 		FinishScriptRun();
 	}
 }

--- a/scribus/plugins/scriptplugin/scriptercore.cpp
+++ b/scribus/plugins/scriptplugin/scriptercore.cpp
@@ -276,7 +276,8 @@ void ScripterCore::slotRunScriptFileArgs(QString fileName, QStringList arguments
 	char *comm[arguments.size()];
 	for (int i = 0; i < arguments.size(); i++)
 	{
-		comm[i] = arguments.at(i).mid(0).toLocal8Bit().data(); // TODO fix here: unexpected border effects. all comm[*] point to same (last) value for i... despite mid() that should create a copy.
+		comm[i] = new char[arguments.at(i).toLocal8Bit().size()+1]; //+1 to allow adding '\0'. may be useless, don't know how to check.
+		strcpy(comm[i],arguments.at(i).toLocal8Bit().data()+'\0');
 	}
 	PySys_SetArgv(arguments.size(), comm);
 	

--- a/scribus/plugins/scriptplugin/scriptercore.cpp
+++ b/scribus/plugins/scriptplugin/scriptercore.cpp
@@ -229,8 +229,7 @@ void ScripterCore::RecentScript(QString fn)
 
 void ScripterCore::slotRunScriptFile(QString fileName, bool inMainInterpreter)
 {
-	QStringList arguments = QStringList();
-	slotRunScriptFile(fileName, arguments, inMainInterpreter);
+	slotRunScriptFile(fileName, QStringList(), inMainInterpreter);
 }
 
 void ScripterCore::slotRunScriptFile(QString fileName, QStringList arguments, bool inMainInterpreter)

--- a/scribus/plugins/scriptplugin/scriptercore.h
+++ b/scribus/plugins/scriptplugin/scriptercore.h
@@ -39,8 +39,9 @@ public slots:
 	void StdScript(QString filebasename);
 	void RecentScript(QString fn);
 	void slotRunScriptFile(QString fileName, bool inMainInterpreter = false);
+	void slotRunScriptFileArgs(QString fileName, QStringList arguments, bool inMainInterpreter = false);
 	void slotRunPythonScript(); // needed for running python script from CLI
-	void slotRunScript(const QString Script);
+	void slotRunScript(const QString script);
 	void slotInteractiveScript(bool);
 	void slotExecute();
 	/*! \brief Show docstring of the script to the user.

--- a/scribus/plugins/scriptplugin/scriptercore.h
+++ b/scribus/plugins/scriptplugin/scriptercore.h
@@ -39,7 +39,7 @@ public slots:
 	void StdScript(QString filebasename);
 	void RecentScript(QString fn);
 	void slotRunScriptFile(QString fileName, bool inMainInterpreter = false);
-	void slotRunScriptFileArgs(QString fileName, QStringList arguments, bool inMainInterpreter = false);
+	void slotRunScriptFile(QString fileName, QStringList arguments, bool inMainInterpreter = false);
 	void slotRunPythonScript(); // needed for running python script from CLI
 	void slotRunScript(const QString script);
 	void slotInteractiveScript(bool);

--- a/scribus/scribusapp.cpp
+++ b/scribus/scribusapp.cpp
@@ -218,11 +218,11 @@ void ScribusQApp::parseCommandLine()
 	useGUI = true;
 	//We are going to run something other than command line help
 	QString qtARG_SCRIPTARG_PREFIX = QString(ARG_SCRIPTARG_PREFIX);
-	int i = 1;
-	for( ; i < argsc; i++) { //handle all options (not positional parameters)
-		arg = args[i];
+	int argi = 1;
+	for( ; argi < argsc; argi++) { //handle options (not positional parameters)
+		arg = args[argi];
 
-		if ((arg == ARG_LANG || arg == ARG_LANG_SHORT) && (++i < argsc)) {
+		if ((arg == ARG_LANG || arg == ARG_LANG_SHORT) && (++argi < argsc)) {
 			continue;
 		} else if ( arg == ARG_CONSOLE || arg == ARG_CONSOLE_SHORT ) {
 			continue;
@@ -238,12 +238,12 @@ void ScribusQApp::parseCommandLine()
 			showFontInfo=true;
 		} else if (arg == ARG_PROFILEINFO || arg == ARG_PROFILEINFO_SHORT) {
 			showProfileInfo=true;
-		} else if ((arg == ARG_DISPLAY || arg==ARG_DISPLAY_SHORT || arg==ARG_DISPLAY_QT) && ++i < argsc) {
+		} else if ((arg == ARG_DISPLAY || arg==ARG_DISPLAY_SHORT || arg==ARG_DISPLAY_QT) && ++argi < argsc) {
 			// allow setting of display, QT expect the option -display <display_name> so we discard the
 			// last argument. FIXME: Qt only understands -display not --display and -d , we need to work
 			// around this.
 		} else if (arg == ARG_PREFS || arg == ARG_PREFS_SHORT) {
-			prefsUserFile = QFile::decodeName(args[i + 1].toLocal8Bit());
+			prefsUserFile = QFile::decodeName(args[argi + 1].toLocal8Bit());
 			if (!QFileInfo(prefsUserFile).exists()) {
 				showHeader();
 				if (prefsUserFile.left(1) == "-" || prefsUserFile.left(2) == "--") {
@@ -254,40 +254,40 @@ void ScribusQApp::parseCommandLine()
 				showUsage();
 				std::exit(EXIT_FAILURE);
 			} else {
-				++i;
+				++argi;
 			}
 		} else if (strncmp(arg.toLocal8Bit().data(),"-psn_",4) == 0)
 		{
 			// Andreas Vox: Qt/Mac has -psn_blah flags that must be accepted.
 		} else if (arg == ARG_PYTHONSCRIPT || arg == ARG_PYTHONSCRIPT_SHORT) {
-			pythonScript = QFile::decodeName(args[i + 1].toLocal8Bit());
+			pythonScript = QFile::decodeName(args[argi + 1].toLocal8Bit());
 			if (!QFileInfo(pythonScript).exists()) {
 				showHeader();
 				if (pythonScript.left(1) == "-" || pythonScript.left(2) == "--") {
-					std::cout << tr("Invalid option: ").toLocal8Bit().data() << pythonScript.toLocal8Bit().data() << std::endl;
+					std::cout << tr("Invalid argument: ").toLocal8Bit().data() << pythonScript.toLocal8Bit().data() << std::endl;
 				} else {
 					std::cout << tr("File %1 does not exist, aborting.").arg(pythonScript).toLocal8Bit().data() << std::endl;
 				}
 				showUsage();
 				std::exit(EXIT_FAILURE);
 			} else {
-				++i;
+				++argi;
 			}
 		} else if (arg == CMD_OPTIONS_END) { //double dash, indicates end of command line options, see http://unix.stackexchange.com/questions/11376/what-does-double-dash-mean-also-known-as-bare-double-dash
-			i++;
+			argi++;
 			break;
 		} else if (arg.startsWith(qtARG_SCRIPTARG_PREFIX)) {
 			pythonScriptArgs.append( arg.mid(qtARG_SCRIPTARG_PREFIX.size()-1) ); //-1 to get the dash from prefix
-			if (!args[i+1].startsWith("-")) {
-				pythonScriptArgs.append( QFile::decodeName(args[++i].toLocal8Bit()) );
+			if (!args[argi+1].startsWith("-")) {
+				pythonScriptArgs.append( QFile::decodeName(args[++argi].toLocal8Bit()) );
 			}
 		} else { //argument is not a known option, but either positional parameter or invalid.
 			break;
 		}
 	}
-	//remaining arguments, if any
-	for ( ; i<argsc; i++) {
-		fileName = QFile::decodeName(args[i].toLocal8Bit());
+	//remaining (positional) arguments, if any
+	for ( ; argi<argsc; argi++) {
+		fileName = QFile::decodeName(args[argi].toLocal8Bit());
 		if (!QFileInfo(fileName).exists()) {
 			showHeader();
 			if (fileName.left(1) == "-" || fileName.left(2) == "--") {

--- a/scribus/scribusapp.cpp
+++ b/scribus/scribusapp.cpp
@@ -156,7 +156,8 @@ void ScribusQApp::parseCommandLine()
 	int testargsc;
 #endif
 	showFontInfo=false;
-	showProfileInfo=false;
+	showProfileInfo=false;	
+	bool neverSplash = false;
 
 	//Parse for command line options
 	// Qt5 port: do this in a Qt compatible manner
@@ -213,7 +214,7 @@ void ScribusQApp::parseCommandLine()
 		}
 		else if (arg == ARG_NEVERSPLASH || arg == ARG_NEVERSPLASH_SHORT) {
 			showSplash = false;
-			neverSplash(true);
+			neverSplash = true;
 		} else if (arg == ARG_NOGUI || arg == ARG_NOGUI_SHORT) {
 			useGUI=false;
 		} else if (arg == ARG_FONTINFO || arg == ARG_FONTINFO_SHORT) {
@@ -227,13 +228,7 @@ void ScribusQApp::parseCommandLine()
 		} else if (arg == ARG_PREFS || arg == ARG_PREFS_SHORT) {
 			prefsUserFile = QFile::decodeName(args[argi + 1].toLocal8Bit());
 			if (!QFileInfo(prefsUserFile).exists()) {
-				showHeader();
-				if (prefsUserFile.left(1) == "-" || prefsUserFile.left(2) == "--") {
-					std::cout << tr("Invalid argument: ").toLocal8Bit().data() << prefsUserFile.toLocal8Bit().data() << std::endl;
-				} else {
-					std::cout << tr("File %1 does not exist, aborting.").arg(prefsUserFile).toLocal8Bit().data() << std::endl;
-				}
-				showUsage();
+				showError(prefsUserFile);
 				std::exit(EXIT_FAILURE);
 			} else {
 				++argi;
@@ -244,13 +239,7 @@ void ScribusQApp::parseCommandLine()
 		} else if (arg == ARG_PYTHONSCRIPT || arg == ARG_PYTHONSCRIPT_SHORT) {
 			pythonScript = QFile::decodeName(args[argi + 1].toLocal8Bit());
 			if (!QFileInfo(pythonScript).exists()) {
-				showHeader();
-				if (pythonScript.left(1) == "-" || pythonScript.left(2) == "--") {
-					std::cout << tr("Invalid argument: ").toLocal8Bit().data() << pythonScript.toLocal8Bit().data() << std::endl;
-				} else {
-					std::cout << tr("File %1 does not exist, aborting.").arg(pythonScript).toLocal8Bit().data() << std::endl;
-				}
-				showUsage();
+				showError(pythonScript);
 				std::exit(EXIT_FAILURE);
 			} else {
 				++argi;
@@ -266,13 +255,7 @@ void ScribusQApp::parseCommandLine()
 	for ( ; argi<argsc; argi++) {
 		fileName = QFile::decodeName(args[argi].toLocal8Bit());
 		if (!QFileInfo(fileName).exists()) {
-			showHeader();
-			if (fileName.left(1) == "-" || fileName.left(2) == "--") {
-				std::cout << tr("Invalid argument: %1").arg(fileName).toLocal8Bit().data() << std::endl;
-			} else {
-				std::cout << tr("File %1 does not exist, aborting.").arg(fileName).toLocal8Bit().data() << std::endl;
-			}
-			showUsage();
+			showError(filename);
 			std::exit(EXIT_FAILURE);
 		} else {
 			filesToLoad.append(fileName);
@@ -303,6 +286,10 @@ void ScribusQApp::parseCommandLine()
 	//Dont run the GUI init process called from main.cpp, and return
 	if (header) {		
 		std::exit(EXIT_SUCCESS);
+	}
+	//proceed
+	if(neverSplash) {
+		neverSplash(true);
 	}
 	
 }
@@ -579,6 +566,18 @@ void ScribusQApp::showHeader()
 	ts << QString("%1 %2").arg( tr("Wiki")+":",          descwidth).arg("http://wiki.scribus.net"); endl(ts);
 	ts << QString("%1 %2").arg( tr("Issues")+":",        descwidth).arg("http://bugs.scribus.net"); endl(ts);
 	endl(ts);
+}
+
+void ScribusQApp::showError(QString arg)
+{
+	showHeader();
+	if (arg.left(1) == "-" || arg.left(2) == "--") {
+		std::cout << tr("Invalid argument: %1").arg(arg).toLocal8Bit().data() << std::endl;
+	} else {
+		std::cout << tr("File %1 does not exist, aborting.").arg(arg).toLocal8Bit().data() << std::endl;
+	}
+	showUsage();
+	std::cout << tr("Scribus Version").toLocal8Bit().data() << " " << VERSION << std::endl;
 }
 
 void ScribusQApp::neverSplash(bool splashOff)

--- a/scribus/scribusapp.cpp
+++ b/scribus/scribusapp.cpp
@@ -72,8 +72,8 @@ for which a new license (GPL+exception) is in place.
 #define ARG_UPGRADECHECK "--upgradecheck"
 #define ARG_TESTS "--tests"
 #define ARG_PYTHONSCRIPT "--python-script"
-#define ARG_SCRIPTARG_PREFIX "--python-arg"   // directly followed by <param name> <param value>
-#define ARG_SCRIPTFLAG_PREFIX "--python-flag" // directly followed by <param name>
+#define ARG_SCRIPTARG_PREFIX "--python-arg-"   // directly followed by <param name> <param value>
+#define ARG_SCRIPTFLAG_PREFIX "--python-flag-" // directly followed by <param name>
 
 #define ARG_VERSION_SHORT "-v"
 #define ARG_HELP_SHORT "-h"
@@ -274,13 +274,13 @@ void ScribusQApp::parseCommandLine()
 				++i;
 			}
 		} else if (arg.startsWith(qtARG_SCRIPTARG_PREFIX)) {
-	 		QString arg_name = arg.mid(qtARG_SCRIPTARG_PREFIX.size());
+	 		QString arg_name = arg.mid(qtARG_SCRIPTARG_PREFIX.size()-1); //-1 to get the dash from prefix
 	 		QString arg_value = QFile::decodeName(args[++i].toLocal8Bit());
 	 		//std::cout << tr("got one script argument: %1 with value %2").arg(arg_name).arg(arg_value).toLocal8Bit().data() << std::endl;				
 	 		pythonScriptArgs.append(arg_name);
 	 		pythonScriptArgs.append(arg_value);
 		} else if (arg.startsWith(qtARG_SCRIPTFLAG_PREFIX)) {
-	 		QString arg_name = arg.mid(qtARG_SCRIPTFLAG_PREFIX.size());
+	 		QString arg_name = arg.mid(qtARG_SCRIPTFLAG_PREFIX.size()-1); //-1 to get the dash from prefix
 	 		//std::cout << tr("got one script flag: %1 ").arg(arg_name).toLocal8Bit().data() << std::endl;
 	 		pythonScriptArgs.append(arg_name);	 		
 		} else { // (last) positional argument
@@ -514,8 +514,8 @@ void ScribusQApp::showUsage()
 	printArgLine(ts, ARG_UPGRADECHECK_SHORT, ARG_UPGRADECHECK, tr("Download a file from the Scribus website and show the latest available version") );
 	printArgLine(ts, ARG_VERSION_SHORT, ARG_VERSION, tr("Output version information and exit") );
 	printArgLine(ts, ARG_PYTHONSCRIPT_SHORT, qPrintable(QString("%1 <%2>").arg(ARG_PYTHONSCRIPT).arg(tr("filename"))), tr("Run filename in Python scripter") );
-	ts << (QString("       %1<%2> <%3>   ").arg(ARG_SCRIPTARG_PREFIX).arg(tr("argumentname")).arg(tr("value"))) << tr("Argument passed on to python script with its value, no effect without -py"); endl(ts);
-	ts << (QString("       %1<%2>              ").arg(ARG_SCRIPTFLAG_PREFIX).arg(tr("flagname"))) << tr("Argument passed on to python script with no value, no effect without -py"); endl(ts);
+	ts << (QString("       %1<%2> <%3>  ").arg(ARG_SCRIPTARG_PREFIX).arg(tr("argumentname")).arg(tr("value"))) << tr("Argument passed on to python script with its value, no effect without -py"); endl(ts);
+	ts << (QString("       %1<%2>             ").arg(ARG_SCRIPTFLAG_PREFIX).arg(tr("flagname"))) << tr("Argument passed on to python script with no value, no effect without -py"); endl(ts);
  	printArgLine(ts, ARG_NOGUI_SHORT, ARG_NOGUI, tr("Do not start GUI") );
 	
 #if defined(_WIN32) && !defined(_CONSOLE)

--- a/scribus/scribusapp.cpp
+++ b/scribus/scribusapp.cpp
@@ -253,7 +253,7 @@ void ScribusQApp::parseCommandLine()
 			if (!QFileInfo(prefsUserFile).exists()) {
 				showHeader();
 				if (prefsUserFile.left(1) == "-" || prefsUserFile.left(2) == "--") {
-					std::cout << tr("Invalid option: ").toLocal8Bit().data() << prefsUserFile.toLocal8Bit().data() << std::endl;
+					std::cout << tr("Invalid argument: ").toLocal8Bit().data() << prefsUserFile.toLocal8Bit().data() << std::endl;
 				} else {
 					std::cout << tr("File %1 does not exist, aborting.").arg(prefsUserFile).toLocal8Bit().data() << std::endl;
 				}

--- a/scribus/scribusapp.cpp
+++ b/scribus/scribusapp.cpp
@@ -514,8 +514,8 @@ void ScribusQApp::showUsage()
 	printArgLine(ts, ARG_UPGRADECHECK_SHORT, ARG_UPGRADECHECK, tr("Download a file from the Scribus website and show the latest available version") );
 	printArgLine(ts, ARG_VERSION_SHORT, ARG_VERSION, tr("Output version information and exit") );
 	printArgLine(ts, ARG_PYTHONSCRIPT_SHORT, qPrintable(QString("%1 <%2>").arg(ARG_PYTHONSCRIPT).arg(tr("filename"))), tr("Run filename in Python scripter") );
-	ts << (QString("     %1<%2> <%3>    ").arg(ARG_SCRIPTARG_PREFIX).arg(tr("argumentname")).arg(tr("value"))) << tr("Argument passed on to python script with its value, no effect without -py"); endl(ts);
-	ts << (QString("     %1<%2>               ").arg(ARG_SCRIPTFLAG_PREFIX).arg(tr("flagname"))) << tr("Argument passed on to python script with no value, no effect without -py"); endl(ts);
+	ts << (QString("       %1<%2> <%3>   ").arg(ARG_SCRIPTARG_PREFIX).arg(tr("argumentname")).arg(tr("value"))) << tr("Argument passed on to python script with its value, no effect without -py"); endl(ts);
+	ts << (QString("       %1<%2>              ").arg(ARG_SCRIPTFLAG_PREFIX).arg(tr("flagname"))) << tr("Argument passed on to python script with no value, no effect without -py"); endl(ts);
  	printArgLine(ts, ARG_NOGUI_SHORT, ARG_NOGUI, tr("Do not start GUI") );
 	
 #if defined(_WIN32) && !defined(_CONSOLE)

--- a/scribus/scribusapp.cpp
+++ b/scribus/scribusapp.cpp
@@ -157,7 +157,7 @@ void ScribusQApp::parseCommandLine()
 #endif
 	showFontInfo=false;
 	showProfileInfo=false;	
-	bool neverSplash = false;
+	bool neversplash = false;
 
 	//Parse for command line options
 	// Qt5 port: do this in a Qt compatible manner
@@ -214,7 +214,7 @@ void ScribusQApp::parseCommandLine()
 		}
 		else if (arg == ARG_NEVERSPLASH || arg == ARG_NEVERSPLASH_SHORT) {
 			showSplash = false;
-			neverSplash = true;
+			neversplash = true;
 		} else if (arg == ARG_NOGUI || arg == ARG_NOGUI_SHORT) {
 			useGUI=false;
 		} else if (arg == ARG_FONTINFO || arg == ARG_FONTINFO_SHORT) {
@@ -255,7 +255,7 @@ void ScribusQApp::parseCommandLine()
 	for ( ; argi<argsc; argi++) {
 		fileName = QFile::decodeName(args[argi].toLocal8Bit());
 		if (!QFileInfo(fileName).exists()) {
-			showError(filename);
+			showError(fileName);
 			std::exit(EXIT_FAILURE);
 		} else {
 			filesToLoad.append(fileName);
@@ -288,7 +288,7 @@ void ScribusQApp::parseCommandLine()
 		std::exit(EXIT_SUCCESS);
 	}
 	//proceed
-	if(neverSplash) {
+	if(neversplash) {
 		neverSplash(true);
 	}
 	

--- a/scribus/scribusapp.cpp
+++ b/scribus/scribusapp.cpp
@@ -173,9 +173,15 @@ void ScribusQApp::parseCommandLine()
 		arg = args[argi];
 
 		if (arg == ARG_SCRIPTARG || arg == ARG_SCRIPTARG_SHORT) { //needs to be first to give precedence to script argument name over scribus' options
-			pythonScriptArgs.append(args[++argi]); // arg name
-			if (!args[argi+1].startsWith("-")) {   // arg value
-				pythonScriptArgs.append( QFile::decodeName(args[++argi].toLocal8Bit()) );
+			if (++argi<argsc and (args[argi] != CMD_OPTIONS_END)) {
+				pythonScriptArgs.append(args[argi]); // script argument
+			} else {
+				std::cout << tr("Invalid argument use: '%1' requires to be followed by <argument> [value]").arg(arg).toLocal8Bit().data() << std::endl;
+				showUsage();
+				std::exit(EXIT_FAILURE);
+			}
+			if (++argi<argsc and !args[argi].startsWith("-")) {   // arg value
+				pythonScriptArgs.append( QFile::decodeName(args[argi].toLocal8Bit()) );
 			}
 		}
 		else if ((arg == ARG_LANG || arg == ARG_LANG_SHORT) && (++argi < argsc)) {
@@ -505,7 +511,7 @@ void ScribusQApp::showUsage()
 	printArgLine(ts, ARG_UPGRADECHECK_SHORT, ARG_UPGRADECHECK, tr("Download a file from the Scribus website and show the latest available version") );
 	printArgLine(ts, ARG_VERSION_SHORT, ARG_VERSION, tr("Output version information and exit") );
 	printArgLine(ts, ARG_PYTHONSCRIPT_SHORT, qPrintable(QString("%1 <%2>").arg(ARG_PYTHONSCRIPT).arg(tr("filename"))), tr("Run filename in Python scripter") );
-	printArgLine(ts, ARG_SCRIPTARG_SHORT, qPrintable(QString("%1 <%2> [%3]").arg(ARG_SCRIPTARG).arg(tr("name")).arg(tr("value"))), tr("Argument passed on to python script, with an optional value, no effect without -py") );
+	printArgLine(ts, ARG_SCRIPTARG_SHORT, qPrintable(QString("%1 <%2> [%3]").arg(ARG_SCRIPTARG).arg(tr("argument")).arg(tr("value"))), tr("Argument passed on to python script, with an optional value, no effect without -py") );
 	printArgLine(ts, ARG_NOGUI_SHORT, ARG_NOGUI, tr("Do not start GUI") );
 	ts << (QString("     %1").arg(CMD_OPTIONS_END,-39)) << tr("Explicit end of command line options"); endl(ts);
  	

--- a/scribus/scribusapp.h
+++ b/scribus/scribusapp.h
@@ -77,6 +77,7 @@ class SCRIBUS_API ScribusQApp : public QApplication
 	private:
 		ScribusCore* m_ScCore;
 		void showHeader();
+		void showError(QString arg);
 		void showVersion();
 		/*!
 		\author Franz Schmid

--- a/scribus/scribusapp.h
+++ b/scribus/scribusapp.h
@@ -23,6 +23,7 @@ for which a new license (GPL+exception) is in place.
 #define SCRIBUSAPP_H
 #include <QApplication>
 #include <QString>
+#include <QStringList>
 
 #include "scribusapi.h"
 
@@ -71,6 +72,7 @@ class SCRIBUS_API ScribusQApp : public QApplication
 		const QString& currGUILanguage() { return GUILang; }
 		ScDLManager* dlManager() { return m_scDLMgr; }
 		QString pythonScript; // script to be run in python from CLI
+		QStringList pythonScriptArgs; // command line arguments and flags for script from CLI
 
 	private:
 		ScribusCore* m_ScCore;


### PR DESCRIPTION
adding 2 options to pass arguments to python script run in Scribus from command line (to be used with -py and -g), after short discussion with a-l-e  on irc.

    --python-arg<argumentname> <value>   Argument passed on to python script with its value, no effect without -py
    --python-flag<flagname>              Argument passed on to python script with no value, no effect without -py


