### PR TITLE
Unify PDF/X Headline

### DIFF
--- a/scribus/ui/prefs_pdfexportbase.ui
+++ b/scribus/ui/prefs_pdfexportbase.ui
@@ -1212,7 +1212,7 @@
               </font>
              </property>
              <property name="text">
-              <string>PDF/X-3 Output Intent</string>
+              <string>PDF/X Output Intent</string>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
The output profile setting (Document Setup \ PDF Export \ Pre-Press) also affects PDF/X-4 and should have the same headline as in the "Save as PDF" dialog.

May also update https://github.com/scribusproject/scribus/blob/master/Scribus.pot and translations.