### PR TITLE
Fix Doxygen Background Color

### DIFF
--- a/devel-doc/templates/scribus.css
+++ b/devel-doc/templates/scribus.css
@@ -4,7 +4,7 @@
  */
 body {
     color: #000000;
-    background-color: #1e72a8;
+    /* background-color: #1e72a8; */
     padding: 0px;
     margin: 0px;
     font-family: Trebuchet, "Trebuchet MS", Tahoma, Verdana, Arial, Sans-Serif;
@@ -91,7 +91,7 @@ a.qindex, a.qindexHL {
 	font-size:12px;
 	font-weight:bold;
 	text-decoration: none;
-} 
+}
 a.qindex:hover, a.qindexHL:hover {
 	background: #cbb072;
 }
@@ -176,4 +176,3 @@ div.memitem {
     border-right: 0px;
     border-bottom: 0px;
 }
-


### PR DESCRIPTION
Remove the background color definition for the Doxygen css file. 

The color defined for the body was EXACTLY the same color used in the "a:link, a:visited, a:hover" selector which has the effect of making the Doxygen output look broken as you can't see any text. Looking at the other Scribus websites it looks like plain white is the preferred background color so I have simply removed the color specification.

Please accept this pull request as it will aid us in Zurich to contribute to Ale's EPUB plug-in as part of our weekly C++ sessions.