### PR TITLE
Remove "Open Type" from "Open Type Font Features" (#69)

### DIFF
--- a/scribus/ui/propertiespalette_text.cpp
+++ b/scribus/ui/propertiespalette_text.cpp
@@ -109,8 +109,8 @@ PropertiesPalette_Text::PropertiesPalette_Text( QWidget* parent) : QWidget(paren
 
 	//>>Advanced Settings
 	fontfeaturesWidget = new PropertyWidget_FontFeatures(textTree);
-	fontfeaturesWidgetItem = textTree->addItem(fontfeaturesWidget, tr("Open Type Font Features"));
-//	fontfeaturesWidgetItem = textTree->addWidget( tr("Open Type Font Features"), fontfeaturesWidget);
+	fontfeaturesWidgetItem = textTree->addItem(fontfeaturesWidget, tr("Font Features"));
+//	fontfeaturesWidgetItem = textTree->addWidget( tr("Font Features"), fontfeaturesWidget);
 
 
 	pathTextWidgets = new PropertyWidget_PathText(textTree);


### PR DESCRIPTION
Remove Open Type and keep it as 'Font Features' per @khaledhosny (#69)
[skip ci]