### PR TITLE
Fix build with poppler-0.76

### DIFF
--- a/scribus/plugins/import/pdf/slaoutput.cpp
+++ b/scribus/plugins/import/pdf/slaoutput.cpp
@@ -429,8 +429,7 @@ bool SlaOutputDev::handleLinkAnnot(Annot* annota, double xCoor, double yCoor, do
 			{
 				if (dst->isPageRef())
 				{
-					Ref dstr = dst->getPageRef();
-					pagNum = pdfDoc->findPage(dstr.num, dstr.gen);
+					pagNum = pdfDoc->findPage(dst->getPageRef());
 				}
 				else
 					pagNum = dst->getPageNum();
@@ -451,8 +450,7 @@ bool SlaOutputDev::handleLinkAnnot(Annot* annota, double xCoor, double yCoor, do
 					{
 						if (dstn->isPageRef())
 						{
-							Ref dstr = dstn->getPageRef();
-							pagNum = pdfDoc->findPage(dstr.num, dstr.gen);
+							pagNum = pdfDoc->findPage(dstn->getPageRef());
 						}
 						else
 							pagNum = dstn->getPageNum();
@@ -931,8 +929,7 @@ void SlaOutputDev::handleActions(PageItem* ite, AnnotWidget *ano)
 				{
 					if (dst->isPageRef())
 					{
-						Ref dstr = dst->getPageRef();
-						pagNum = pdfDoc->findPage(dstr.num, dstr.gen);
+						pagNum = pdfDoc->findPage(dst->getPageRef());
 					}
 					else
 						pagNum = dst->getPageNum();
@@ -955,8 +952,7 @@ void SlaOutputDev::handleActions(PageItem* ite, AnnotWidget *ano)
 						{
 							if (dstn->isPageRef())
 							{
-								Ref dstr = dstn->getPageRef();
-								pagNum = pdfDoc->findPage(dstr.num, dstr.gen);
+								pagNum = pdfDoc->findPage(dstn->getPageRef());
 							}
 							else
 								pagNum = dstn->getPageNum();


### PR DESCRIPTION
findPage(int num, int gen) -> findPage(const Ref ref)

https://gitlab.freedesktop.org/poppler/poppler/commit/244c7d6926463b079b1f96e34d9e4451d352942e

Please note that this is just a quick fix to see if scribus builds after the changes (it does). It is not backwards compatible.