### PR TITLE
Add bullet support for scripter plugin

### DIFF
--- a/doc/de/scripterapi-styles.html
+++ b/doc/de/scripterapi-styles.html
@@ -162,6 +162,7 @@
 <li>dropcaplines [optional] -> height (in lines) of the caps if used</li>
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
+<li>"bullet" [optional] -> string to use as bullet</li>
 </ul>
 </p>
 <p>If you wish to skip a number of settings, unfortunately, this command will not accept null values, i.e., a series of commas. You <i>must</i> put some integer value for each of the potential parameters. For example, imagine you wish to only specify a name for the Paragraph Style, and the Character Style. Your command should be something like:</p>

--- a/doc/en/scripterapi-styles.html
+++ b/doc/en/scripterapi-styles.html
@@ -162,6 +162,7 @@
 <li>dropcaplines [optional] -> height (in lines) of the caps if used</li>
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
+<li>"bullet" [optional] -> string to use as bullet</li>
 </ul>
 </p>
 <p>If you wish to skip a number of settings, unfortunately, this command will not accept null values, i.e., a series of commas. You <i>must</i> put some integer value for each of the potential parameters. For example, imagine you wish to only specify a name for the Paragraph Style, and the Character Style. Your command should be something like:</p>

--- a/doc/fr/scripterapi-styles.html
+++ b/doc/fr/scripterapi-styles.html
@@ -159,6 +159,7 @@
 <li>dropcaplines [optionnel] -> la hauteur des lettrines en nombre de lignes si l'utilisation de lettrines est activée</li>
 <li>dropcapoffset [optionnel] -> décalage horizontal des lettrines si l'utilisation de lettrines est activée</li>
 <li>"charstyle" [optionnel] -> nom du style de caractère à utiliser</li>
+<li>"bullet" [optionnel] -> signe pour l'énumération</li>
 </ul>
 </p>
 <p>Si vous désirez omettre un certain nombre d'éléments, cette fonction n'acceptera pas de valeurs null, i.e., une série de virgule. Vous <i>devez</i> spécifier un paramètre entier pour chacun des paramètres omis. Par example, si vous désirez spécifier uniquement un nom de style de paragraphe et un nom de style de caractère, votre appel de fonction ressemblera à ceci:</p>

--- a/doc/it/scripterapi-styles.html
+++ b/doc/it/scripterapi-styles.html
@@ -162,6 +162,7 @@
 <li>dropcaplines [optional] -> height (in lines) of the caps if used</li>
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
+<li>"bullet" [optional] -> string to use as bullet</li>
 </ul>
 </p>
 <p>If you wish to skip a number of settings, unfortunately, this command will not accept null values, i.e., a series of commas. You <i>must</i> put some integer value for each of the potential parameters. For example, imagine you wish to only specify a name for the Paragraph Style, and the Character Style. Your command should be something like:</p>

--- a/scribus/plugins/scriptplugin/cmdstyle.cpp
+++ b/scribus/plugins/scriptplugin/cmdstyle.cpp
@@ -69,23 +69,33 @@ PyObject *scribus_createparagraphstyle(PyObject* /* self */, PyObject* args, PyO
 	tmpParagraphStyle.setRightMargin(rightMargin);
 	tmpParagraphStyle.setGapBefore(gapBefore);
 	tmpParagraphStyle.setGapAfter(gapAfter);
-	if (hasDropCap == 0)
-		tmpParagraphStyle.setHasDropCap(false);
-	else if (hasDropCap == 1)
+
+	if (hasDropCap == 1)
+	{
+		tmpParagraphStyle.setDropCapLines(dropCapLines);
 		tmpParagraphStyle.setHasDropCap(true);
+		tmpParagraphStyle.setHasBullet(false);
+		tmpParagraphStyle.setHasNum(false);
+	}
 	else
 	{
-		PyErr_SetString(PyExc_ValueError, QObject::tr("hasdropcap has to be 0 or 1.","python error").toLocal8Bit().constData());
-		return nullptr;
+		tmpParagraphStyle.setHasDropCap(false);
 	}
-	tmpParagraphStyle.setDropCapLines(dropCapLines);
+
+	if (strlen(bullet) > 0)
+	{
+		tmpParagraphStyle.setBulletStr(bullet);
+		tmpParagraphStyle.setHasDropCap(false);
+		tmpParagraphStyle.setHasBullet(true);
+		tmpParagraphStyle.setHasNum(false);
+	}
+	else
+	{
+		tmpParagraphStyle.setHasBullet(false);
+	}
+
 	tmpParagraphStyle.setParEffectOffset(peOffset);
 	tmpParagraphStyle.charStyle().setParent(charStyle);
-
-	if (strlen(bullet) > 0) {
-		tmpParagraphStyle.setHasBullet(true);
-		tmpParagraphStyle.setBulletStr(bullet);
-	}
 
 	StyleSet<ParagraphStyle> tmpStyleSet;
 	tmpStyleSet.create(tmpParagraphStyle);

--- a/scribus/plugins/scriptplugin/cmdstyle.cpp
+++ b/scribus/plugins/scriptplugin/cmdstyle.cpp
@@ -38,15 +38,18 @@ PyObject *scribus_createparagraphstyle(PyObject* /* self */, PyObject* args, PyO
 			const_cast<char*>("dropcaplines"),
 			const_cast<char*>("dropcapoffset"),
 			const_cast<char*>("charstyle"),
+			const_cast<char*>("bullet"),
 			nullptr};
 	char *name = const_cast<char*>(""), *charStyle = const_cast<char*>("");
+	char *bullet = const_cast<char*>("");
 	int lineSpacingMode = 0, alignment = 0, dropCapLines = 2, hasDropCap = 0;
 	double lineSpacing = 15.0, leftMargin = 0.0, rightMargin = 0.0;
 	double gapBefore = 0.0, gapAfter = 0.0, firstIndent = 0.0, peOffset = 0;
-	if (!PyArg_ParseTupleAndKeywords(args, keywords, "es|ididddddiides",
+	if (!PyArg_ParseTupleAndKeywords(args, keywords, "es|ididddddiideses",
 		 keywordargs, "utf-8", &name, &lineSpacingMode, &lineSpacing, &alignment,
 		&leftMargin, &rightMargin, &gapBefore, &gapAfter, &firstIndent,
-		&hasDropCap, &dropCapLines, &peOffset, "utf-8", &charStyle))
+		&hasDropCap, &dropCapLines, &peOffset, "utf-8", &charStyle,
+		"utf-8", &bullet))
 		return nullptr;
 	if (!checkHaveDocument())
 		return nullptr;
@@ -78,6 +81,11 @@ PyObject *scribus_createparagraphstyle(PyObject* /* self */, PyObject* args, PyO
 	tmpParagraphStyle.setDropCapLines(dropCapLines);
 	tmpParagraphStyle.setParEffectOffset(peOffset);
 	tmpParagraphStyle.charStyle().setParent(charStyle);
+
+	if (strlen(bullet) > 0) {
+		tmpParagraphStyle.setHasBullet(true);
+		tmpParagraphStyle.setBulletStr(bullet);
+	}
 
 	StyleSet<ParagraphStyle> tmpStyleSet;
 	tmpStyleSet.create(tmpParagraphStyle);

--- a/scribus/plugins/scriptplugin/cmdstyle.cpp
+++ b/scribus/plugins/scriptplugin/cmdstyle.cpp
@@ -97,6 +97,12 @@ PyObject *scribus_createparagraphstyle(PyObject* /* self */, PyObject* args, PyO
 	tmpParagraphStyle.setParEffectOffset(peOffset);
 	tmpParagraphStyle.charStyle().setParent(charStyle);
 
+	if (strlen(bullet) > 0 && hasDropCap == 1)
+	{
+		PyErr_SetString(PyExc_ValueError, QObject::tr("hasdropcap and bullet are not allowed to be specified together.","python error").toLocal8Bit().constData());
+		return nullptr;
+	}
+
 	StyleSet<ParagraphStyle> tmpStyleSet;
 	tmpStyleSet.create(tmpParagraphStyle);
 	ScCore->primaryMainWindow()->doc->redefineStyles(tmpStyleSet, false);

--- a/scribus/plugins/scriptplugin/cmdstyle.h
+++ b/scribus/plugins/scriptplugin/cmdstyle.h
@@ -40,6 +40,7 @@ hasdropcap [optional] -> specifies if there are caps (1 = yes, 0 = no)\n\n\
 dropcaplines [optional] -> height (in lines) of the caps if used\n\n\
 dropcapoffset [optional] -> offset of the caps if used\n\n\
 \"charstyle\" [optional] -> char style to use\n\n\
+\"bullet\" [optional] -> string to use as bullet\n\n\
 "));
 /*! 02.01.2007 - 05.01.2007 : Joachim Neu : Create a paragraph style.
   		Special thanks go to avox for helping me! */


### PR DESCRIPTION
Add support to the scripter plugin to define a bullet string while creating a new paragraph style.

## Example usage
```py
createParagraphStyle('MyNewEnumerationStyle', bullet='-')
```