### PR TITLE
Add tabs support for scripter plugin

### DIFF
--- a/doc/de/scripterapi-constants.html
+++ b/doc/de/scripterapi-constants.html
@@ -299,10 +299,10 @@ you write 'value*mm/inch' .</p>
 <table><tr><td>
 <dl>
 	<dt>TAB_LEFT</dt>
-	<dt>TAB_CENTER</dt>
 	<dt>TAB_RIGHT</dt>
-	<dt>TAB_JUSTIFIED</dt>
-	<dt>TAB_EXTENDED</dt>
+	<dt>TAB_PERIOD</dt>
+	<dt>TAB_COMMA</dt>
+	<dt>TAB_CENTER</dt>
 </dl>
 </td></tr></table>
 

--- a/doc/de/scripterapi-constants.html
+++ b/doc/de/scripterapi-constants.html
@@ -295,5 +295,16 @@ you write 'value*mm/inch' .</p>
 </dl>
 </td></tr></table>
 
+<h4>Tab alignment</h4>
+<table><tr><td>
+<dl>
+	<dt>TAB_LEFT</dt>
+	<dt>TAB_CENTER</dt>
+	<dt>TAB_RIGHT</dt>
+	<dt>TAB_JUSTIFIED</dt>
+	<dt>TAB_EXTENDED</dt>
+</dl>
+</td></tr></table>
+
 </body>
 </html>

--- a/doc/de/scripterapi-styles.html
+++ b/doc/de/scripterapi-styles.html
@@ -163,11 +163,11 @@
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
 <li>"bullet" [optional] -> string to use as bullet</li>
-<li>"tabs" [optional] -> a comma seperated list of tab definitions
+<li>"tabs" [optional] -> a list of tab definitions
 <ul>
-    <li>a tab is defined with the following format "type|position|fillchar"</li>
-    <li>type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5</li>
+    <li>a tab is defined as a tuple with the following format (position,type,fillchar)</li>
     <li>position [required] -> float value for the position</li>
+    <li>type [optional] -> left: 0 [default], right: 1, period: 2, comma: 3, center: 4</li>
     <li>fillchar [optional] -> the char to fill the space; default is none</li>
 </ul>
 </li>

--- a/doc/de/scripterapi-styles.html
+++ b/doc/de/scripterapi-styles.html
@@ -163,6 +163,14 @@
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
 <li>"bullet" [optional] -> string to use as bullet</li>
+<li>"tabs" [optional] -> a comma seperated list of tab definitions
+<ul>
+    <li>a tab is defined with the following format "type|position|fillchar"</li>
+    <li>type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5</li>
+    <li>position [required] -> float value for the position</li>
+    <li>fillchar [optional] -> the char to fill the space; default is none</li>
+</ul>
+</li>
 </ul>
 </p>
 <p>If you wish to skip a number of settings, unfortunately, this command will not accept null values, i.e., a series of commas. You <i>must</i> put some integer value for each of the potential parameters. For example, imagine you wish to only specify a name for the Paragraph Style, and the Character Style. Your command should be something like:

--- a/doc/en/scripterapi-constants.html
+++ b/doc/en/scripterapi-constants.html
@@ -311,10 +311,10 @@ you write 'value*mm/inch' .</p>
 <table><tr><td>
 <dl>
 	<dt>TAB_LEFT</dt>
-	<dt>TAB_CENTER</dt>
 	<dt>TAB_RIGHT</dt>
-	<dt>TAB_JUSTIFIED</dt>
-	<dt>TAB_EXTENDED</dt>
+	<dt>TAB_PERIOD</dt>
+	<dt>TAB_COMMA</dt>
+	<dt>TAB_CENTER</dt>
 </dl>
 </td></tr></table>
 

--- a/doc/en/scripterapi-constants.html
+++ b/doc/en/scripterapi-constants.html
@@ -307,5 +307,16 @@ you write 'value*mm/inch' .</p>
 </dl>
 </td></tr></table>
 
+<h4>Tab alignment</h4>
+<table><tr><td>
+<dl>
+	<dt>TAB_LEFT</dt>
+	<dt>TAB_CENTER</dt>
+	<dt>TAB_RIGHT</dt>
+	<dt>TAB_JUSTIFIED</dt>
+	<dt>TAB_EXTENDED</dt>
+</dl>
+</td></tr></table>
+
 </body>
 </html>

--- a/doc/en/scripterapi-styles.html
+++ b/doc/en/scripterapi-styles.html
@@ -163,11 +163,11 @@
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
 <li>"bullet" [optional] -> string to use as bullet</li>
-<li>"tabs" [optional] -> a comma seperated list of tab definitions
+<li>"tabs" [optional] -> a list of tab definitions
 <ul>
-    <li>a tab is defined with the following format "type|position|fillchar"</li>
-    <li>type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5</li>
+    <li>a tab is defined as a tuple with the following format (position,type,fillchar)</li>
     <li>position [required] -> float value for the position</li>
+    <li>type [optional] -> left: 0 [default], right: 1, period: 2, comma: 3, center: 4</li>
     <li>fillchar [optional] -> the char to fill the space; default is none</li>
 </ul>
 </li>

--- a/doc/en/scripterapi-styles.html
+++ b/doc/en/scripterapi-styles.html
@@ -163,6 +163,14 @@
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
 <li>"bullet" [optional] -> string to use as bullet</li>
+<li>"tabs" [optional] -> a comma seperated list of tab definitions
+<ul>
+    <li>a tab is defined with the following format "type|position|fillchar"</li>
+    <li>type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5</li>
+    <li>position [required] -> float value for the position</li>
+    <li>fillchar [optional] -> the char to fill the space; default is none</li>
+</ul>
+</li>
 </ul>
 </p>
 <p>If you wish to skip a number of settings, unfortunately, this command will not accept null values, i.e., a series of commas. You <i>must</i> put some integer value for each of the potential parameters. For example, imagine you wish to only specify a name for the Paragraph Style, and the Character Style. Your command should be something like:

--- a/doc/fr/scripterapi-constants.html
+++ b/doc/fr/scripterapi-constants.html
@@ -303,6 +303,17 @@ Ainsi, pour convertir les pouces en points, il suffit d'écrire 'valeur/inch'; p
 </dl>
 </td></tr></table>
 
+<h4>Tab alignment</h4>
+<table><tr><td>
+<dl>
+	<dt>TAB_LEFT</dt>
+	<dt>TAB_CENTER</dt>
+	<dt>TAB_RIGHT</dt>
+	<dt>TAB_JUSTIFIED</dt>
+	<dt>TAB_EXTENDED</dt>
+</dl>
+</td></tr></table>
+
 </body>
 </html>
  

--- a/doc/fr/scripterapi-constants.html
+++ b/doc/fr/scripterapi-constants.html
@@ -307,10 +307,10 @@ Ainsi, pour convertir les pouces en points, il suffit d'écrire 'valeur/inch'; p
 <table><tr><td>
 <dl>
 	<dt>TAB_LEFT</dt>
-	<dt>TAB_CENTER</dt>
 	<dt>TAB_RIGHT</dt>
-	<dt>TAB_JUSTIFIED</dt>
-	<dt>TAB_EXTENDED</dt>
+	<dt>TAB_PERIOD</dt>
+	<dt>TAB_COMMA</dt>
+	<dt>TAB_CENTER</dt>
 </dl>
 </td></tr></table>
 

--- a/doc/fr/scripterapi-styles.html
+++ b/doc/fr/scripterapi-styles.html
@@ -160,11 +160,11 @@
 <li>dropcapoffset [optionnel] -> décalage horizontal des lettrines si l'utilisation de lettrines est activée</li>
 <li>"charstyle" [optionnel] -> nom du style de caractère à utiliser</li>
 <li>"bullet" [optionnel] -> chaîne de caractère à utiliser pour les puces</li>
-<li>"tabs" [optional] -> a comma seperated list of tab definitions
+<li>"tabs" [optional] -> a list of tab definitions
 <ul>
-    <li>a tab is defined with the following format "type|position|fillchar"</li>
-    <li>type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5</li>
+    <li>a tab is defined as a tuple with the following format (position,type,fillchar)</li>
     <li>position [required] -> float value for the position</li>
+    <li>type [optional] -> left: 0 [default], right: 1, period: 2, comma: 3, center: 4</li>
     <li>fillchar [optional] -> the char to fill the space; default is none</li>
 </ul>
 </li>

--- a/doc/fr/scripterapi-styles.html
+++ b/doc/fr/scripterapi-styles.html
@@ -160,6 +160,14 @@
 <li>dropcapoffset [optionnel] -> décalage horizontal des lettrines si l'utilisation de lettrines est activée</li>
 <li>"charstyle" [optionnel] -> nom du style de caractère à utiliser</li>
 <li>"bullet" [optionnel] -> chaîne de caractère à utiliser pour les puces</li>
+<li>"tabs" [optional] -> a comma seperated list of tab definitions
+<ul>
+    <li>a tab is defined with the following format "type|position|fillchar"</li>
+    <li>type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5</li>
+    <li>position [required] -> float value for the position</li>
+    <li>fillchar [optional] -> the char to fill the space; default is none</li>
+</ul>
+</li>
 </ul>
 </p>
 <p>Si vous désirez omettre un certain nombre d'éléments, cette fonction n'acceptera pas de valeurs null, i.e., une série de virgule. Vous <i>devez</i> spécifier un paramètre entier pour chacun des paramètres omis. Par example, si vous désirez spécifier uniquement un nom de style de paragraphe et un nom de style de caractère, votre appel de fonction ressemblera à ceci:

--- a/doc/it/scripterapi-constants.html
+++ b/doc/it/scripterapi-constants.html
@@ -299,10 +299,10 @@ you write 'value*mm/inch' .</p>
 <table><tr><td>
 <dl>
 	<dt>TAB_LEFT</dt>
-	<dt>TAB_CENTER</dt>
 	<dt>TAB_RIGHT</dt>
-	<dt>TAB_JUSTIFIED</dt>
-	<dt>TAB_EXTENDED</dt>
+	<dt>TAB_PERIOD</dt>
+	<dt>TAB_COMMA</dt>
+	<dt>TAB_CENTER</dt>
 </dl>
 </td></tr></table>
 

--- a/doc/it/scripterapi-constants.html
+++ b/doc/it/scripterapi-constants.html
@@ -295,5 +295,16 @@ you write 'value*mm/inch' .</p>
 </dl>
 </td></tr></table>
 
+<h4>Tab alignment</h4>
+<table><tr><td>
+<dl>
+	<dt>TAB_LEFT</dt>
+	<dt>TAB_CENTER</dt>
+	<dt>TAB_RIGHT</dt>
+	<dt>TAB_JUSTIFIED</dt>
+	<dt>TAB_EXTENDED</dt>
+</dl>
+</td></tr></table>
+
 </body>
 </html>

--- a/doc/it/scripterapi-styles.html
+++ b/doc/it/scripterapi-styles.html
@@ -163,11 +163,11 @@
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
 <li>"bullet" [optional] -> string to use as bullet</li>
-<li>"tabs" [optional] -> a comma seperated list of tab definitions
+<li>"tabs" [optional] -> a list of tab definitions
 <ul>
-    <li>a tab is defined with the following format "type|position|fillchar"</li>
-    <li>type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5</li>
+    <li>a tab is defined as a tuple with the following format (position,type,fillchar)</li>
     <li>position [required] -> float value for the position</li>
+    <li>type [optional] -> left: 0 [default], right: 1, period: 2, comma: 3, center: 4</li>
     <li>fillchar [optional] -> the char to fill the space; default is none</li>
 </ul>
 </li>

--- a/doc/it/scripterapi-styles.html
+++ b/doc/it/scripterapi-styles.html
@@ -163,6 +163,14 @@
 <li>dropcapoffset [optional] -> offset of the caps if used</li>
 <li>"charstyle" [optional] -> char style to use</li>
 <li>"bullet" [optional] -> string to use as bullet</li>
+<li>"tabs" [optional] -> a comma seperated list of tab definitions
+<ul>
+    <li>a tab is defined with the following format "type|position|fillchar"</li>
+    <li>type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5</li>
+    <li>position [required] -> float value for the position</li>
+    <li>fillchar [optional] -> the char to fill the space; default is none</li>
+</ul>
+</li>
 </ul>
 </p>
 <p>If you wish to skip a number of settings, unfortunately, this command will not accept null values, i.e., a series of commas. You <i>must</i> put some integer value for each of the potential parameters. For example, imagine you wish to only specify a name for the Paragraph Style, and the Character Style. Your command should be something like:

--- a/scribus/plugins/scriptplugin/cmdstyle.h
+++ b/scribus/plugins/scriptplugin/cmdstyle.h
@@ -44,7 +44,7 @@ dropcapoffset [optional] -> offset of the caps if used\n\n\
 \"tabs\" [optional] -> a list containg tab definitions\n\n\
 -> a tab is defined as a tuple with the following format (position,type,fillchar)\"\n\n\
 -> position [required] -> float value for the position\n\n\
--> type [optional] -> left: 0 [default], center: 1, right: 2, justified: 3, extended: 4\n\n\
+-> type [optional] -> left: 0 [default], right: 1, period: 2, comma: 3, center: 4\n\n\
 -> fillchar [optional] -> the char to fill the space; default is none\n\n\
 "));
 /*! 02.01.2007 - 05.01.2007 : Joachim Neu : Create a paragraph style.

--- a/scribus/plugins/scriptplugin/cmdstyle.h
+++ b/scribus/plugins/scriptplugin/cmdstyle.h
@@ -41,6 +41,11 @@ dropcaplines [optional] -> height (in lines) of the caps if used\n\n\
 dropcapoffset [optional] -> offset of the caps if used\n\n\
 \"charstyle\" [optional] -> char style to use\n\n\
 \"bullet\" [optional] -> string to use as bullet\n\n\
+\"tabs\" [optional] -> a comma seperated list of tab definitions\n\n\
+-> a tab is defined with the following format \"type|position|fillchar\"\n\n\
+-> type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5\n\n\
+-> position [required] -> float value for the position\n\n\
+-> fillchar [optional] -> the char to fill the space; default is none\n\n\
 "));
 /*! 02.01.2007 - 05.01.2007 : Joachim Neu : Create a paragraph style.
   		Special thanks go to avox for helping me! */

--- a/scribus/plugins/scriptplugin/cmdstyle.h
+++ b/scribus/plugins/scriptplugin/cmdstyle.h
@@ -41,10 +41,10 @@ dropcaplines [optional] -> height (in lines) of the caps if used\n\n\
 dropcapoffset [optional] -> offset of the caps if used\n\n\
 \"charstyle\" [optional] -> char style to use\n\n\
 \"bullet\" [optional] -> string to use as bullet\n\n\
-\"tabs\" [optional] -> a comma seperated list of tab definitions\n\n\
--> a tab is defined with the following format \"type|position|fillchar\"\n\n\
--> type [required] -> left: 1, right: 2, fullstop: 3, comma: 4, center: 5\n\n\
+\"tabs\" [optional] -> a list containg tab definitions\n\n\
+-> a tab is defined as a tuple with the following format (position,type,fillchar)\"\n\n\
 -> position [required] -> float value for the position\n\n\
+-> type [optional] -> left: 0 [default], center: 1, right: 2, justified: 3, extended: 4\n\n\
 -> fillchar [optional] -> the char to fill the space; default is none\n\n\
 "));
 /*! 02.01.2007 - 05.01.2007 : Joachim Neu : Create a paragraph style.

--- a/scribus/plugins/scriptplugin/scriptplugin.cpp
+++ b/scribus/plugins/scriptplugin/scriptplugin.cpp
@@ -57,6 +57,7 @@ for which a new license (GPL+exception) is in place.
 #include "ui/propertiespalette.h"
 #include "ui/scmwmenumanager.h"
 #include "units.h"
+#include "styles/paragraphstyle.h"
 
 
 #include <QApplication>
@@ -784,6 +785,12 @@ void initscribus(ScribusMainWindow *mainWin)
 	PyDict_SetItemString(d, const_cast<char*>("PAGE_2"), Py_BuildValue(const_cast<char*>("i"), 1));
 	PyDict_SetItemString(d, const_cast<char*>("PAGE_3"), Py_BuildValue(const_cast<char*>("i"), 2));
 	PyDict_SetItemString(d, const_cast<char*>("PAGE_4"), Py_BuildValue(const_cast<char*>("i"), 3));
+	// tab alignment
+	PyDict_SetItemString(d, const_cast<char*>("TAB_LEFT"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::LeftAligned));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_CENTER"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::Centered));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_RIGHT"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::RightAligned));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_JUSTIFIED"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::Justified));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_EXTENDED"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::Extended));
 
 	// Measurement units understood by Scribus's units.cpp functions are exported as constant conversion
 	// factors to be used from Python.

--- a/scribus/plugins/scriptplugin/scriptplugin.cpp
+++ b/scribus/plugins/scriptplugin/scriptplugin.cpp
@@ -57,7 +57,6 @@ for which a new license (GPL+exception) is in place.
 #include "ui/propertiespalette.h"
 #include "ui/scmwmenumanager.h"
 #include "units.h"
-#include "styles/paragraphstyle.h"
 
 
 #include <QApplication>

--- a/scribus/plugins/scriptplugin/scriptplugin.cpp
+++ b/scribus/plugins/scriptplugin/scriptplugin.cpp
@@ -786,11 +786,11 @@ void initscribus(ScribusMainWindow *mainWin)
 	PyDict_SetItemString(d, const_cast<char*>("PAGE_3"), Py_BuildValue(const_cast<char*>("i"), 2));
 	PyDict_SetItemString(d, const_cast<char*>("PAGE_4"), Py_BuildValue(const_cast<char*>("i"), 3));
 	// tab alignment
-	PyDict_SetItemString(d, const_cast<char*>("TAB_LEFT"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::LeftAligned));
-	PyDict_SetItemString(d, const_cast<char*>("TAB_CENTER"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::Centered));
-	PyDict_SetItemString(d, const_cast<char*>("TAB_RIGHT"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::RightAligned));
-	PyDict_SetItemString(d, const_cast<char*>("TAB_JUSTIFIED"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::Justified));
-	PyDict_SetItemString(d, const_cast<char*>("TAB_EXTENDED"), Py_BuildValue(const_cast<char*>("i"), ParagraphStyle::AlignmentType::Extended));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_LEFT"), Py_BuildValue(const_cast<char*>("i"), 0));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_RIGHT"), Py_BuildValue(const_cast<char*>("i"), 1));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_PERIOD"), Py_BuildValue(const_cast<char*>("i"), 2));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_COMMA"), Py_BuildValue(const_cast<char*>("i"), 3));
+	PyDict_SetItemString(d, const_cast<char*>("TAB_CENTER"), Py_BuildValue(const_cast<char*>("i"), 4));
 
 	// Measurement units understood by Scribus's units.cpp functions are exported as constant conversion
 	// factors to be used from Python.


### PR DESCRIPTION
Add support to the scripter plugin to define tabs while creating a new paragraph style.

## Example usage
```py
createParagraphStyle('MyNewStyle', tabs='1|8|. , 2|20')
```