### PR TITLE
Add positionToPoint() and getMark() functions to the Scripter API.

### DIFF
--- a/scribus/plugins/scriptplugin/cmdtext.h
+++ b/scribus/plugins/scriptplugin/cmdtext.h
@@ -561,4 +561,26 @@ May raise WrongFrameTypeError if the target frame is not a text frame\n\
 /*! Is PDF bookmark? */
 PyObject *scribus_ispdfbookmark(PyObject * /*self*/, PyObject* args);
 
+/*! docstring */
+PyDoc_STRVAR(scribus_positiontopoint__doc__,
+QT_TR_NOOP("positionToPoint(pos, [\"name\"]) -> (x,y,width,height)\n\
+\n\
+Returns a (x, y, width, height) tuple based on the character at position\n\
+\"pos\" in the text frame \"name\". If \"name\" is not given the currently\n\
+selected item is used.\n\
+"));
+/*! Point for glyth at position */
+PyObject *scribus_positiontopoint(PyObject * /*self*/, PyObject* args);
+
+/*! docstring */
+PyDoc_STRVAR(scribus_getmark__doc__,
+QT_TR_NOOP("getMark(pos, [\"name\"]) -> (type,text)\n\
+\n\
+Returns a (type, text) tuple for the mark at position pos in object \"name\".\n\
+If \"name\" is not given the currently selected item is used. If there is no\n\
+mark at that position, type is -1.\n\
+"));
+/*! Returns info about mark */
+PyObject *scribus_getmark(PyObject * /*self*/, PyObject* args);
+
 #endif

--- a/scribus/plugins/scriptplugin/scriptplugin.cpp
+++ b/scribus/plugins/scriptplugin/scriptplugin.cpp
@@ -407,6 +407,8 @@ PyMethodDef scribus_methods[] = {
 	{const_cast<char*>("getUnit"), (PyCFunction)scribus_getunit, METH_NOARGS, tr(scribus_getunit__doc__)},
 	{const_cast<char*>("getVGuides"), (PyCFunction)scribus_getVguides, METH_NOARGS, tr(scribus_getVguides__doc__)},
 	{const_cast<char*>("getXFontNames"), (PyCFunction)scribus_xfontnames, METH_NOARGS, tr(scribus_xfontnames__doc__)},
+	{const_cast<char*>("positionToPoint"), scribus_positiontopoint, METH_VARARGS, tr(scribus_positiontopoint__doc__)},
+	{const_cast<char*>("getMark"), scribus_getmark, METH_VARARGS, tr(scribus_getmark__doc__)},
 	{const_cast<char*>("gotoPage"), scribus_gotopage, METH_VARARGS, tr(scribus_gotopage__doc__)},
 	{const_cast<char*>("groupObjects"), (PyCFunction)scribus_groupobj, METH_VARARGS, tr(scribus_groupobj__doc__)},
 	{const_cast<char*>("haveDoc"), (PyCFunction)scribus_havedoc, METH_NOARGS, tr(scribus_havedoc__doc__)},


### PR DESCRIPTION
Add two new functions to the Scripter API.

positionToPoint() lets you get information about where a given character in a text frame is located.
getMark() lets you get information about a mark in a text frame.

These two additions make it possible to write python scripts to add PDF links based on the content of a text frame.