### PR TITLE
Fix build with >=poppler-24.03.0

### DIFF
--- a/scribus/plugins/import/pdf/slaoutput.cpp
+++ b/scribus/plugins/import/pdf/slaoutput.cpp
@@ -1731,7 +1731,11 @@ bool SlaOutputDev::axialShadedFill(GfxState *state, GfxAxialShading *shading, do
 	VGradient FillGradient = VGradient(VGradient::linear);
 	FillGradient.clearStops();
 	GfxColorSpace *color_space = shading->getColorSpace();
+#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 3, 0)
+	if (func->getType() == Function::Type::Stitching)
+#else
 	if (func->getType() == 3)
+#endif
 	{
 		StitchingFunction *stitchingFunc = (StitchingFunction*)func;
 		const double *bounds = stitchingFunc->getBounds();
@@ -1753,7 +1757,11 @@ bool SlaOutputDev::axialShadedFill(GfxState *state, GfxAxialShading *shading, do
 			FillGradient.addStop( ScColorEngine::getShadeColor(m_doc->PageColors[stopColor], m_doc, shade), stopPoint, 0.5, 1.0, stopColor, shade );
 		}
 	}
+#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 3, 0)
+	else if ((func->getType() == Function::Type::Exponential) || (func->getType() == Function::Type::Sampled))
+#else
 	else if ((func->getType() == 2) || (func->getType() == 0))
+#endif
 	{
 		GfxColor stop1;
 		shading->getColor(0.0, &stop1);
@@ -1865,7 +1873,11 @@ bool SlaOutputDev::radialShadedFill(GfxState *state, GfxRadialShading *shading, 
 	VGradient FillGradient = VGradient(VGradient::linear);
 	FillGradient.clearStops();
 	GfxColorSpace *color_space = shading->getColorSpace();
+#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 3, 0)
+	if (func->getType() == Function::Type::Stitching)
+#else
 	if (func->getType() == 3)
+#endif
 	{
 		StitchingFunction *stitchingFunc = (StitchingFunction*)func;
 		const double *bounds = stitchingFunc->getBounds();
@@ -1887,7 +1899,11 @@ bool SlaOutputDev::radialShadedFill(GfxState *state, GfxRadialShading *shading, 
 			FillGradient.addStop( ScColorEngine::getShadeColor(m_doc->PageColors[stopColor], m_doc, shade), stopPoint, 0.5, 1.0, stopColor, shade );
 		}
 	}
+#if POPPLER_ENCODED_VERSION >= POPPLER_VERSION_ENCODE(24, 3, 0)
+	else if ((func->getType() == Function::Type::Exponential) || (func->getType() == Function::Type::Sampled))
+#else
 	else if ((func->getType() == 2) || (func->getType() == 0))
+#endif
 	{
 		GfxColor stop1;
 		shading->getColor(0.0, &stop1);


### PR DESCRIPTION
Fixes build errors caused by:

"Use an enum for Function getType"
Upstream commit [6e3824d45d42cb806a28a2df84e4ab6bb3587083](https://gitlab.freedesktop.org/poppler/poppler/-/commit/6e3824d45d42cb806a28a2df84e4ab6bb3587083)