### PR TITLE
Introduce scroll delta for CTRL+touchpad-zoom

### DIFF
--- a/scribus/scribusview.cpp
+++ b/scribus/scribusview.cpp
@@ -3158,7 +3158,12 @@ void ScribusView::wheelEvent(QWheelEvent *w)
 	if (w->modifiers() == Qt::ControlModifier)
 	{
 		FPoint mp = m_canvas->globalToCanvas(w->globalPos());
-		w->delta() > 0 ? slotZoomIn(mp.x(), mp.y() , true) : slotZoomOut(mp.x(), mp.y(), true);
+		wheelAccumulatedDelta += w->delta();
+		if (abs(wheelAccumulatedDelta) >= QWheelEvent::DefaultDeltasPerStep)
+		{
+			wheelAccumulatedDelta > 0 ? slotZoomIn(mp.x(), mp.y() , true) : slotZoomOut(mp.x(), mp.y(), true);
+			wheelAccumulatedDelta = 0;
+		}
 	}
 	else
 	{

--- a/scribus/scribusview.h
+++ b/scribus/scribusview.h
@@ -298,6 +298,7 @@ private:
 	bool linkAfterDraw { false };
 	bool ImageAfterDraw { false };
 	QStack<ViewState> m_viewStates;
+	int wheelAccumulatedDelta { 0 };
 
 private slots:
 	void setZoom();


### PR DESCRIPTION
To make zooming the document via touchpad, i.e. CTRL+two-finger-move, usable, a scroll delta was introduced. That way, not every tiny finger movement triggers a zoom event but a certain default delta has to be surpassed before zooming.